### PR TITLE
OpenSSL 1.1 compatibility & Pre-1.1 shims.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,42 +56,48 @@ TARGETS=        radmind ${BINTARGETS}
 
 RADMIND_OBJ=    version.o daemon.o command.o argcargv.o code.o \
                 cksum.o base64.o mkdirs.o applefile.o connect.o \
-		list.o wildcard.o logname.o pathcmp.o tls.o
+		list.o wildcard.o logname.o pathcmp.o tls.o \
+		openssl_compat.o
 
 FSDIFF_OBJ=     version.o fsdiff.o argcargv.o transcript.o llist.o code.o \
                 hardlink.o cksum.o base64.o pathcmp.o radstat.o applefile.o \
-		list.o wildcard.o
+		list.o wildcard.o openssl_compat.o
 
 KTCHECK_OBJ=    version.o ktcheck.o argcargv.o retr.o base64.o code.o \
                 cksum.o list.o llist.o connect.o applefile.o tls.o pathcmp.o \
-		progress.o mkdirs.o report.o rmdirs.o mkprefix.o
+		progress.o mkdirs.o report.o rmdirs.o mkprefix.o \
+		openssl_compat.o
 
 LAPPLY_OBJ=     version.o lapply.o argcargv.o code.o base64.o retr.o \
                 radstat.o update.o cksum.o connect.o pathcmp.o progress.o \
-                applefile.o report.o tls.o mkprefix.o
+                applefile.o report.o tls.o mkprefix.o openssl_compat.o
 
 LCREATE_OBJ=    version.o lcreate.o argcargv.o code.o connect.o progress.o \
-                stor.o applefile.o base64.o cksum.o radstat.o tls.o
+                stor.o applefile.o base64.o cksum.o radstat.o tls.o \
+		openssl_compat.o
 
 LCKSUM_OBJ=     version.o lcksum.o argcargv.o cksum.o base64.o code.o \
-                progress.o pathcmp.o applefile.o connect.o root.o
+                progress.o pathcmp.o applefile.o connect.o root.o \
+		openssl_compat.o
 
 LMERGE_OBJ=     version.o lmerge.o argcargv.o code.o pathcmp.o mkdirs.o \
 		root.o
 
 LFDIFF_OBJ=     version.o lfdiff.o argcargv.o connect.o retr.o cksum.o \
                 progress.o base64.o applefile.o code.o tls.o pathcmp.o \
-		transcript.o list.o radstat.o hardlink.o mkprefix.o wildcard.o
+		transcript.o list.o radstat.o hardlink.o mkprefix.o \
+		wildcard.o openssl_compat.o
 
 REPO_OBJ=	version.o repo.o report.o argcargv.o connect.o code.o tls.o
 
 T2PKG_OBJ=	version.o t2pkg.o argcargv.o transcript.o connect.o code.o \
 		hardlink.o cksum.o base64.o pathcmp.o radstat.o applefile.o \
-		list.o rmdirs.o mkdirs.o wildcard.o progress.o
+		list.o rmdirs.o mkdirs.o wildcard.o progress.o \
+		openssl_compat.o
 
 TWHICH_OBJ=     version.o twhich.o argcargv.o transcript.o llist.o code.o \
                 hardlink.o cksum.o base64.o pathcmp.o radstat.o applefile.o \
-		list.o wildcard.o
+		list.o wildcard.o openssl_compat.o
 
 LSORT_OBJ=     version.o lsort.o pathcmp.o code.o argcargv.o
 
@@ -101,6 +107,10 @@ version.o : version.c
 	${CC} ${CFLAGS} \
 		-DVERSION=\"`cat ${srcdir}/VERSION`\" \
 		-c ${srcdir}/version.c
+
+openssl_compat.o : openssl_compat.c
+	${CC} ${CFLAGS} \
+	-c ${srcdir}/openssl_compat.c
 
 transcript.o : transcript.c
 	${CC} ${CFLAGS} \

--- a/cksum.c
+++ b/cksum.c
@@ -20,7 +20,7 @@
 
 #include <openssl/evp.h>
 
-#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
+#include "openssl_compat.h" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "cksum.h"
 #include "base64.h"

--- a/cksum.c
+++ b/cksum.c
@@ -20,6 +20,7 @@
 
 #include <openssl/evp.h>
 
+#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "cksum.h"
 #include "base64.h"
@@ -41,21 +42,22 @@ do_fcksum( int fd, char *cksum_b64 )
     off_t		size = 0;
     unsigned char	buf[ 8192 ];
     extern EVP_MD	*md;
-    EVP_MD_CTX		mdctx;
+    EVP_MD_CTX		*mdctx = EVP_MD_CTX_new();
     unsigned char 	md_value[ EVP_MAX_MD_SIZE ];
 
-    EVP_DigestInit( &mdctx, md );
+    EVP_DigestInit( mdctx, md );
 
     while (( rr = read( fd, buf, sizeof( buf ))) > 0 ) {
 	size += rr;
-	EVP_DigestUpdate( &mdctx, buf, (unsigned int)rr );
+	EVP_DigestUpdate( mdctx, buf, (unsigned int)rr );
     }
     if ( rr < 0 ) {
 	return( -1 );
     }
 
-    EVP_DigestFinal( &mdctx, md_value, &md_len );
+    EVP_DigestFinal( mdctx, md_value, &md_len );
     base64_e( md_value, md_len, cksum_b64 );
+    EVP_MD_CTX_free(mdctx);
 
     return( size );
 }
@@ -103,13 +105,13 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
     struct as_entry		as_entries_endian[ 3 ];
     unsigned int		md_len;
     extern EVP_MD		*md;
-    EVP_MD_CTX          	mdctx;
+    EVP_MD_CTX          	*mdctx = EVP_MD_CTX_new();
     unsigned char       	md_value[ EVP_MAX_MD_SIZE ];
 
-    EVP_DigestInit( &mdctx, md ); 
+    EVP_DigestInit( mdctx, md ); 
 
     /* checksum applesingle header */
-    EVP_DigestUpdate( &mdctx, (char *)&as_header, AS_HEADERLEN );
+    EVP_DigestUpdate( mdctx, (char *)&as_header, AS_HEADERLEN );
     size += (size_t)AS_HEADERLEN;
 
     /* endian handling, sum big-endian header entries */
@@ -120,12 +122,12 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
     as_entry_netswap( &as_entries_endian[ AS_DFE ] );
 
     /* checksum header entries */
-    EVP_DigestUpdate( &mdctx, (char *)&as_entries_endian,
+    EVP_DigestUpdate( mdctx, (char *)&as_entries_endian,
 		(unsigned int)( 3 * sizeof( struct as_entry )));
     size += sizeof( 3 * sizeof( struct as_entry ));
 
     /* checksum finder info data */
-    EVP_DigestUpdate( &mdctx, afinfo->ai.ai_data, FINFOLEN );
+    EVP_DigestUpdate( mdctx, afinfo->ai.ai_data, FINFOLEN );
     size += FINFOLEN;
 
     /* checksum rsrc fork data */
@@ -140,7 +142,7 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
 	    return( -1 );
 	}
 	while (( rc = read( rfd, buf, sizeof( buf ))) > 0 ) {
-	    EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+	    EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	    size += (size_t)rc;
 	}
 	if ( close( rfd ) < 0 ) {
@@ -156,7 +158,7 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
     }
     /* checksum data fork */
     while (( rc = read( dfd, buf, sizeof( buf ))) > 0 ) {
-	EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+	EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	size += (size_t)rc;
     }
     if ( rc < 0 ) {
@@ -166,8 +168,9 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
 	return( -1 );
     }
 
-    EVP_DigestFinal( &mdctx, md_value, &md_len );
+    EVP_DigestFinal( mdctx, md_value, &md_len );
     base64_e( ( char*)&md_value, md_len, cksum_b64 );
+    EVP_MD_CTX_free();
 
     return( size );
 }

--- a/openssl_compat.c
+++ b/openssl_compat.c
@@ -9,6 +9,15 @@
 #include <string.h>
 #include <openssl/engine.h>
 
+static void *OPENSSL_zalloc(size_t num)
+{
+   void *ret = OPENSSL_malloc(num);
+
+   if (ret != NULL)
+       memset(ret, 0, num);
+   return ret;
+}
+
 EVP_MD_CTX *EVP_MD_CTX_new(void)
 {
     return OPENSSL_zalloc(sizeof(EVP_MD_CTX));

--- a/openssl_compat.c
+++ b/openssl_compat.c
@@ -1,0 +1,24 @@
+/*
+ * OpenSSL Compatibility Shims for pre-1.1.0
+ *
+*/
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef RADMIND_OPENSSL_SHIMS
+#define RADMIND_OPENSSL_SHIMS
+
+#include <string.h>
+#include <openssl/engine.h>
+
+EVP_MD_CTX *EVP_MD_CTX_new(void)
+{
+    return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{
+   EVP_MD_CTX_cleanup(ctx);
+   OPENSSL_free(ctx);
+}
+
+#endif // OPENSSL_RADMIND_SHIMS
+#endif // OLD OPENSSL <1.1.0

--- a/openssl_compat.h
+++ b/openssl_compat.h
@@ -1,0 +1,16 @@
+/*
+ * OpenSSL Compatibility Shims for pre-1.1.0
+ *
+*/
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef RADMIND_OPENSSL_SHIMS
+#define RADMIND_OPENSSL_SHIMS
+
+#include <string.h>
+#include <openssl/engine.h>
+
+static void *OPENSSL_zalloc(size_t num);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+#endif // OPENSSL_RADMIND_SHIMS
+#endif // OLD OPENSSL <1.1.0

--- a/openssl_compat.h
+++ b/openssl_compat.h
@@ -9,8 +9,8 @@
 #include <string.h>
 #include <openssl/engine.h>
 
-static void *OPENSSL_zalloc(size_t num);
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+
 #endif // OPENSSL_RADMIND_SHIMS
 #endif // OLD OPENSSL <1.1.0

--- a/retr.c
+++ b/retr.c
@@ -31,6 +31,7 @@
 
 #include <snet.h>
 
+#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "connect.h"
 #include "cksum.h"
@@ -74,7 +75,7 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
     char		buf[ 8192 ]; 
     ssize_t		rr;
     extern EVP_MD	*md;
-    EVP_MD_CTX		mdctx;
+    EVP_MD_CTX		*mdctx = EVP_MD_CTX_new();
     unsigned char	md_value[ EVP_MAX_MD_SIZE ];
     char		cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
@@ -84,7 +85,7 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
 	    fprintf( stderr, "%s\n", pathdesc );
 	    return( 1 );
 	}
-	EVP_DigestInit( &mdctx, md );
+	EVP_DigestInit( mdctx, md );
     }
 
     if ( verbose ) printf( ">>> RETR %s\n", pathdesc );
@@ -165,7 +166,7 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
 	    goto error2;
 	}
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, buf, (unsigned int)rr );
+	    EVP_DigestUpdate( mdctx, buf, (unsigned int)rr );
 	}
 	if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 	size -= rr;
@@ -197,8 +198,9 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
 
     /* cksum file */
     if ( cksum ) {
-	EVP_DigestFinal( &mdctx, md_value, &md_len );
+	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e( md_value, md_len, cksum_b64 );
+	EVP_MD_CTX_free(mdctx);
 	if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
 		"checksum from server\n", linenum );
@@ -246,7 +248,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
     struct as_entry		ae_ents[ 3 ]; 
     struct timeval		tv;
     extern EVP_MD       	*md;
-    EVP_MD_CTX   	       	mdctx;
+    EVP_MD_CTX   	       	*mdctx;
     unsigned char       	md_value[ EVP_MAX_MD_SIZE ];
     char		       	cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
@@ -256,7 +258,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 	    fprintf( stderr, "%s\n", pathdesc );
             return( 1 );
         }
-        EVP_DigestInit( &mdctx, md );
+        EVP_DigestInit( mdctx, md );
     }
 
     if ( verbose ) printf( ">>> RETR %s\n", pathdesc );
@@ -316,7 +318,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 	return( -1 );
     }
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, (char *)&ah, (unsigned int)rc );
+	EVP_DigestUpdate( mdctx, (char *)&ah, (unsigned int)rc );
     }
 
     /* name temp file */
@@ -373,7 +375,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
     /* Should we check for valid ae_ents here? YES! */
 
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, (char *)&ae_ents, (unsigned int)rc );
+	EVP_DigestUpdate( mdctx, (char *)&ae_ents, (unsigned int)rc );
     }
     if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 
@@ -398,7 +400,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 	goto error2;
     }
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, finfo, (unsigned int)rc );
+	EVP_DigestUpdate( mdctx, finfo, (unsigned int)rc );
     }
     if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
     size -= rc;
@@ -448,7 +450,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 		goto error3;
 	    }
 	    if ( cksum ) {
-		EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+		EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	    }
 	    if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 	    if ( showprogress ) {
@@ -482,7 +484,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 	}
 
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+	    EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	}
 	if ( dodots ) { putc( '.', stdout ); fflush( stdout); }
 	if ( showprogress ) {
@@ -523,8 +525,9 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
     if ( verbose ) printf( "<<< .\n" );
 
     if ( cksum ) {
-	EVP_DigestFinal( &mdctx, md_value, &md_len );
+	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e(( char*)&md_value, md_len, cksum_b64 );
+        EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
 		"checksum from server\n", linenum );

--- a/retr.c
+++ b/retr.c
@@ -31,7 +31,7 @@
 
 #include <snet.h>
 
-#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
+#include "openssl_compat.h" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "connect.h"
 #include "cksum.h"

--- a/stor.c
+++ b/stor.c
@@ -32,7 +32,7 @@
 
 #include <snet.h>
 
-#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
+#include "openssl_compat.h" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "connect.h"
 #include "cksum.h"

--- a/stor.c
+++ b/stor.c
@@ -32,6 +32,7 @@
 
 #include <snet.h>
 
+#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "connect.h"
 #include "cksum.h"
@@ -136,7 +137,7 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
     ssize_t             rr, size = 0;
     unsigned int	md_len;
     extern EVP_MD       *md;
-    EVP_MD_CTX          mdctx;
+    EVP_MD_CTX          *mdctx = EVP_MD_CTX_new();
     unsigned char       md_value[ EVP_MAX_MD_SIZE ];
     char       cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
@@ -146,7 +147,7 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
 	    fprintf( stderr, "line %d: No checksum listed\n", linenum );
 	    exit( 2 );
         }
-	EVP_DigestInit( &mdctx, md );
+	EVP_DigestInit( mdctx, md );
     }
 
     /* Open and stat file */
@@ -202,7 +203,7 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
 	size -= rr;
 	if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, buf, (unsigned int)rr );
+	    EVP_DigestUpdate( mdctx, buf, (unsigned int)rr );
 	}
 	
 	if ( showprogress ) {
@@ -237,8 +238,9 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
 
     /* cksum data sent */
     if ( cksum ) {
-	EVP_DigestFinal( &mdctx, md_value, &md_len );
+	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e( md_value, md_len, cksum_b64 );
+	EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr,
 		"line %d: checksum listed in transcript wrong\n", linenum );
@@ -262,7 +264,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     unsigned int      	md_len;
     unsigned int	rsrc_len;
     extern EVP_MD      	*md;
-    EVP_MD_CTX         	mdctx;
+    EVP_MD_CTX         	*mdctx = EVP_MD_CTX_new();
     unsigned char 	md_value[ EVP_MAX_MD_SIZE ];
     char		cksum_b64[ EVP_MAX_MD_SIZE ];
 
@@ -272,7 +274,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
 	    fprintf( stderr, "line %d: No checksum listed\n", linenum );
 	    exit( 2 );
         }
-        EVP_DigestInit( &mdctx, md );
+        EVP_DigestInit( mdctx, md );
     }
 
     /* Check size listed in transcript */
@@ -339,7 +341,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     }
     size -= AS_HEADERLEN;
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, (char *)&as_header, AS_HEADERLEN );
+	EVP_DigestUpdate( mdctx, (char *)&as_header, AS_HEADERLEN );
     }
     if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
     if ( showprogress ) {
@@ -357,7 +359,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     }
     size -= ( 3 * sizeof( struct as_entry ));
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, (char *)&afinfo->as_ents,
+	EVP_DigestUpdate( mdctx, (char *)&afinfo->as_ents,
 	    (unsigned int)( 3 * sizeof( struct as_entry )));
     }
     if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
@@ -375,7 +377,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     }
     size -= FINFOLEN;
     if ( cksum ) {
-	EVP_DigestUpdate( &mdctx, afinfo->ai.ai_data, FINFOLEN );
+	EVP_DigestUpdate( mdctx, afinfo->ai.ai_data, FINFOLEN );
     }
     if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
     if ( showprogress ) {
@@ -393,7 +395,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
 	    }
 	    size -= rc;
 	    if ( cksum ) {
-		EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+		EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	    } 
 	    if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 	    if ( showprogress ) {
@@ -417,7 +419,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
 	}
 	size -= rc;
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, buf, (unsigned int)rc );
+	    EVP_DigestUpdate( mdctx, buf, (unsigned int)rc );
 	}
     	if ( dodots ) { putc( '.', stdout ); fflush( stdout ); }
 	if ( showprogress ) {
@@ -463,8 +465,9 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
 
     /* cksum data sent */
     if ( cksum ) {
-        EVP_DigestFinal( &mdctx, md_value, &md_len );
+        EVP_DigestFinal( mdctx, md_value, &md_len );
         base64_e( ( char*)&md_value, md_len, cksum_b64 );
+	EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr,
 		"line %d: checksum listed in transcript wrong\n", linenum );

--- a/t2pkg.c
+++ b/t2pkg.c
@@ -23,7 +23,7 @@
 #include <sys/vfs.h>
 #endif /* linux */
 
-#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
+#include "openssl_compat.h" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "base64.h"
 #include "transcript.h"

--- a/t2pkg.c
+++ b/t2pkg.c
@@ -23,6 +23,7 @@
 #include <sys/vfs.h>
 #endif /* linux */
 
+#include "openssl_compat.c" // Compatibility shims for OpenSSL < 1.1.0
 #include "applefile.h"
 #include "base64.h"
 #include "transcript.h"
@@ -62,7 +63,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     char		*trancksum = t->t_pinfo.pi_cksum_b64;
     char		*path = t->t_pinfo.pi_name;
     ssize_t		rr, size = 0;
-    EVP_MD_CTX          mdctx;
+    EVP_MD_CTX          *mdctx = EVP_MD_CTX_new();
     unsigned char       md_value[ EVP_MAX_MD_SIZE ];
     char       		cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 #ifdef __APPLE__
@@ -84,7 +85,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    fprintf( stderr, "line %d: no checksum\n", t->t_linenum );
 	    return( -1 );
 	}
-	EVP_DigestInit( &mdctx, md );
+	EVP_DigestInit( mdctx, md );
     }
 
     if (( rfd = open( src, O_RDONLY, 0 )) < 0 ) {
@@ -151,7 +152,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    goto error2;
 	}
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, ( char * )&header, ( unsigned int )rr );
+	    EVP_DigestUpdate( mdctx, ( char * )&header, ( unsigned int )rr );
 	}
 	size -= rr;
 	if ( showprogress ) {
@@ -176,7 +177,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	as_entry_netswap( &as_ents[ AS_DFE ] );
 
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, ( char * )&as_ents, ( unsigned int )rr );
+	    EVP_DigestUpdate( mdctx, ( char * )&as_ents, ( unsigned int )rr );
 	}
 	size -= rr;
 	if ( showprogress ) {
@@ -199,7 +200,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    goto error2;
 	}
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, finfo, ( unsigned int )rr );
+	    EVP_DigestUpdate( mdctx, finfo, ( unsigned int )rr );
 	}
 	if ( showprogress ) {
 	    progressupdate( rr, path );
@@ -230,7 +231,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 		goto error2;
 	    }
 	    if ( cksum ) {
-		EVP_DigestUpdate( &mdctx, buf, ( unsigned int )rr );
+		EVP_DigestUpdate( mdctx, buf, ( unsigned int )rr );
 	    }
 	    if ( showprogress ) {
 		progressupdate( rr, path );
@@ -249,7 +250,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	 * entries to the checksum digest.
 	 */
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, &as_header, AS_HEADERLEN );
+	    EVP_DigestUpdate( mdctx, &as_header, AS_HEADERLEN );
 
 	    as_ents[AS_FIE].ae_id = ASEID_FINFO;
 	    as_ents[AS_FIE].ae_offset = AS_HEADERLEN +
@@ -275,7 +276,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    as_entry_netswap( &as_ents[ AS_RFE ] );
 	    as_entry_netswap( &as_ents[ AS_DFE ] );
 
-	    EVP_DigestUpdate( &mdctx, ( char * )&as_ents,
+	    EVP_DigestUpdate( mdctx, ( char * )&as_ents,
 					    ( 3 * sizeof( struct as_entry )));
 	} 
 	size -= ( AS_HEADERLEN + ( 3 * sizeof( struct as_entry )) + FINFOLEN );
@@ -293,7 +294,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    }
 	}
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, ai.ai_data, FINFOLEN );
+	    EVP_DigestUpdate( mdctx, ai.ai_data, FINFOLEN );
 	}
 
 	/* read and write the finder info and rsrc fork from the system */
@@ -319,7 +320,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 		    goto error2;
 		}
 		if ( cksum ) {
-		    EVP_DigestUpdate( &mdctx, buf, rr );
+		    EVP_DigestUpdate( mdctx, buf, rr );
 		}
 		size -= rr;
 		if ( showprogress ) {
@@ -355,7 +356,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    goto error2;
 	}
 	if ( cksum ) {
-	    EVP_DigestUpdate( &mdctx, buf, rr );
+	    EVP_DigestUpdate( mdctx, buf, rr );
 	}
 	size -= rr;
 	if ( showprogress ) {
@@ -384,8 +385,9 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     }
 
     if ( cksum ) {
-	EVP_DigestFinal( &mdctx, md_value, &md_len );
+	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e( md_value, md_len, ( char * )cksum_b64 );
+        EVP_MD_CTX_free(mdctx);
 	if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    if ( force ) {
 		fprintf( stderr, "warning: " );


### PR DESCRIPTION
- Handle OpenSSL 1.1 opaque structures for EVP digest functions
- Add openssl_compat.c shims file to support pre-1.1 OpenSSL installs
  (ref. https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes)

Ref. FreeBSD PR (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=232219)