### PR TITLE
Fix misc. compiler warnings about signedness mismatch in strings

### DIFF
--- a/pathcmp.c
+++ b/pathcmp.c
@@ -17,7 +17,7 @@
 #include "pathcmp.h"
 
     int
-pathcasecmp( const unsigned char *p1, const unsigned char *p2,
+pathcasecmp( const char *p1, const char *p2,
     int case_sensitive )
 {
     int		rc;
@@ -46,13 +46,13 @@ pathcasecmp( const unsigned char *p1, const unsigned char *p2,
 
 /* Just like strcmp(), but pays attention to the meaning of '/'.  */
     int 
-pathcmp( const unsigned char *p1, const unsigned char *p2 )
+pathcmp( const char *p1, const char *p2 )
 {
     return( pathcasecmp( p1, p2, 1 ));
 }
 
     int
-ischildcase( const unsigned char *child, const unsigned char *parent, int
+ischildcase( const char *child, const char *parent, int
     case_sensitive )
 {
     int		rc;
@@ -85,7 +85,7 @@ ischildcase( const unsigned char *child, const unsigned char *parent, int
 }
 
     int
-ischild( const unsigned char *child, const unsigned char *parent )
+ischild( const char *child, const char *parent )
 {
     return( ischildcase( child, parent, 1 ));
 }

--- a/pathcmp.h
+++ b/pathcmp.h
@@ -3,9 +3,9 @@
  * All Rights Reserved.  See COPYRIGHT.
  */
 
-int pathcasecmp( const unsigned char *, const unsigned char *,
+int pathcasecmp( const char *, const char *,
 	int case_sensitive );
-int pathcmp( const unsigned char *, const unsigned char * );
-int ischildcase( const unsigned char *, const unsigned char *,
+int pathcmp( const char *, const char * );
+int ischildcase( const char *, const char *,
 	int case_sensitive );
-int ischild( const unsigned char *, const unsigned char * );
+int ischild( const char *, const char * );

--- a/transcript.c
+++ b/transcript.c
@@ -186,7 +186,7 @@ transcript_parse( struct transcript *tran )
 	tran->t_pinfo.pi_stat.st_gid = atoi( argv[ 4 ] );
 	if ( ac == 6 ) {
 	    base64_d( argv[ 5 ], strlen( argv[ 5 ] ),
-		    (char *)tran->t_pinfo.pi_afinfo.ai.ai_data );
+		    (unsigned char *)tran->t_pinfo.pi_afinfo.ai.ai_data );
 	} else {
 	    memset( tran->t_pinfo.pi_afinfo.ai.ai_data, 0, FINFOLEN );
 	}


### PR DESCRIPTION
This PR fixes a bunch of nuisance warnings about arguments of differing signedness (-Wpointer-sign - on by default on FreeBSD and probably other clang platforms).


- Changed pathcmp functions to use signed characters.
  These functions all cast to unsigned char internally where
  needed, and all arguments passed to them / expected by string.h
  helper functions are signed. 

- Apple file info struct is of type uint8_t[] 
  Changed transcript.c calls to use unsigned char* & avoid warning
  in base64_d call.