### PR TITLE
Use AC_HEADER_MAJOR to find header for makedev(3)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Prepare a checked-out source tree for build
+#
+# Make sure git and autoconf are in PATH
+
+# If necessary, populate libsnet/
+if [ -f "./.gitmodules" -a ! -f "./libsnet/.git" ]
+then
+    git submodule init
+    git submodule update
+fi
+
+(cd libsnet && autoconf)
+
+autoconf
+
+exit 0

--- a/config.h.in
+++ b/config.h.in
@@ -34,6 +34,9 @@
 #undef HAVE_WAIT4
 #undef HAVE_STRTOLL
 
+#undef MAJOR_IN_SYSMACROS
+#undef MAJOR_IN_MKDEV
+
 #ifndef MIN
 #define MIN(a,b)        ((a)<(b)?(a):(b))
 #endif /* MIN */

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,17 @@ CHECK_UNIVERSAL_BINARIES
 # mute Mac OS X's helpful notices that using dylib OpenSSL
 MACOSX_MUTE_DEPRECATION_WARNINGS
 
+# Checks for header files
+
+# glibc 2.25 still includes sys/sysmacros.h in sys/types.h but emits
+# deprecation warning which causes compilation failure later with -Werror.
+# So use -Werror here as well to force proper sys/sysmacros.h detection.
+SAVED_CFLAGS="$CFLAGS"
+CFLAGS="$HOST_CFLAGS -Werror"
+AC_HEADER_MAJOR
+CFLAGS="$SAVED_CFLAGS"
+
+
 # Checks for libraries.
 AC_CHECK_LIB(c, inet_aton, libc_inet_aton=yes) 
 if test x$libc_inet_aton != xyes; then 

--- a/transcript.c
+++ b/transcript.c
@@ -7,9 +7,14 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#ifdef sun
+
+#ifdef MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+#ifdef MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
-#endif /* sun */
+#endif
+
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/update.c
+++ b/update.c
@@ -8,9 +8,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>
-#ifdef sun
+
+#ifdef MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+#ifdef MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
-#endif /* sun */
+#endif
+
 #ifdef __APPLE__
 #include <sys/attr.h>
 #endif /* __APPLE__ */


### PR DESCRIPTION
Newer Linuxen have moved makedev(3) and friends from <sys/types.h> to
<sys/sysmacros.h>, and SunOS had its own special case anyway. Let
autoconf do the heavy lifting.

This change should fix issue #323  