### PR TITLE
Fix unchecked path length for file_root

### DIFF
--- a/root.c
+++ b/root.c
@@ -83,7 +83,12 @@ get_root( char *radmind_path, char *path, char *file_root, char *tran_root, char
 		return( -1 );
 	    }
         } else {
-            snprintf( file_root, MAXPATHLEN, "%s/../file", real_path );
+            if ( snprintf( file_root, MAXPATHLEN, "%s/../file",
+		    real_path ) >= MAXPATHLEN ) {
+		fprintf( stderr, "%s/../file: path too long\n",
+		    real_path);
+		return( -1);
+	    }
             snprintf( tran_root, MAXPATHLEN, "%s", real_path );
         }
     }


### PR DESCRIPTION
The fall-through case for file_root could write MAX_PATH+8 characters into a buffer of MAX_PATH size; clang 6 complains that we ignore this possibility so properly check for and handle this situation with an error as done elsewhere in root.c