### PR TITLE
small tweaks to remove compiler warnings, added strlen for null strin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ export CPPFLAGS=-I/usr/kerberos/include
 
 ### Configuring for macOS
 
-Last tested on 10.14
+Last tested on 10.14 (using homebrew)
 
 - Install [Xcode](https://developer.apple.com/xcode/).
 - Install [brew](https://brew.sh).
@@ -89,6 +89,19 @@ brew install autoconf
 brew install openssl
 sudo ln -s /usr/local/opt/openssl /usr/local/openssl 
 ```
+
+Last tested on 10.14 (using fink)
+
+- Install [Xcode](https://developer.apple.com/xcode/).
+- Install [fink](https://finkproject.org).
+
+Run these commands as an admin user.
+
+```
+fink install autoconf
+fink install openssl
+```
+
 
 ### Getting the Source
 
@@ -110,6 +123,13 @@ sh bootstrap.sh
 ```
 
 ### Configuring and Building
+If configure files are to be rebuilt (because we installed it), issue the following commands
+```
+autoconf
+cd libsnet
+autoconf
+cd ..
+```
 
 Now that everything is set up, we have to actually do the configuration and installation. Configure the build:
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -23,7 +23,7 @@ AC_DEFUN([CHECK_SSL],
     AC_MSG_CHECKING(for ssl)
     ssldirs="/usr/local/openssl /usr/lib/openssl /usr/openssl \
 	    /usr/local/ssl /usr/lib/ssl /usr/ssl \
-	    /usr/pkg /usr/local /usr"
+	    /usr/pkg /usr/local /usr /sw /opt/sw"
     AC_ARG_WITH(ssl,
 	    AC_HELP_STRING([--with-ssl=DIR], [path to ssl]),
 	    ssldirs="$withval")
@@ -53,7 +53,7 @@ AC_DEFUN([CHECK_SSL],
 AC_DEFUN([CHECK_ZLIB],
 [
     AC_MSG_CHECKING(for zlib)
-    zlibdirs="/usr /usr/local"
+    zlibdirs="/usr /usr/local /sw /opt/sw"
 	withval=""
     AC_ARG_WITH(zlib,
             [AC_HELP_STRING([--with-zlib=DIR], [path to zlib])],

--- a/cksum.c
+++ b/cksum.c
@@ -43,7 +43,7 @@ do_fcksum( int fd, char *cksum_b64 )
     unsigned char	buf[ 8192 ];
     extern EVP_MD	*md;
     EVP_MD_CTX		*mdctx = EVP_MD_CTX_new();
-    unsigned char 	md_value[ EVP_MAX_MD_SIZE ];
+    unsigned char	md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
 
     EVP_DigestInit( mdctx, md );
 
@@ -106,7 +106,7 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
     unsigned int		md_len;
     extern EVP_MD		*md;
     EVP_MD_CTX          	*mdctx = EVP_MD_CTX_new();
-    unsigned char       	md_value[ EVP_MAX_MD_SIZE ];
+    unsigned char		md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
 
     EVP_DigestInit( mdctx, md );
 
@@ -169,7 +169,7 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
     }
 
     EVP_DigestFinal( mdctx, md_value, &md_len );
-    base64_e( md_value, md_len, cksum_b64 );
+    base64_e( ( unsigned char* ) md_value, md_len, cksum_b64 );
     EVP_MD_CTX_free( mdctx );
 
     return( size );

--- a/contrib/fsspy.c
+++ b/contrib/fsspy.c
@@ -208,7 +208,7 @@ fsevent_callback( ConstFSEventStreamRef ref, void *info,
 	event_insert( &event_head, new );
 
 	if ( debug ) {
-	    printf( "%-10llu %-10lu %s\n", eids[ i ], eflags[ i ], paths[ i ] );
+	  printf( "%-10llu %-10lu %s\n", eids[ i ], ( unsigned long )eflags[ i ], paths[ i ] );
 	}
     }
 

--- a/lmerge.c
+++ b/lmerge.c
@@ -147,7 +147,7 @@ getline:
     strcpy( tran->t_filepath, d_path );
 
     /* Check transcript order */
-    if ( tran->t_prepath != 0 ) {
+    if ( strlen( tran->t_prepath ) != 0 ) {
 	 
 	if ( pathcasecmp( tran->t_filepath, tran->t_prepath,
 		case_sensitive ) <= 0 ) {

--- a/pathcmp.c
+++ b/pathcmp.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "pathcmp.h"
+#include "code.h"
 
     int
 pathcasecmp( const char *p1, const char *p2,

--- a/retr.c
+++ b/retr.c
@@ -76,7 +76,7 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
     ssize_t		rr;
     extern EVP_MD	*md;
     EVP_MD_CTX		*mdctx = EVP_MD_CTX_new();
-    unsigned char	md_value[ EVP_MAX_MD_SIZE ];
+    unsigned char	md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
     char		cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
     if ( cksum ) {
@@ -249,7 +249,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
     struct timeval		tv;
     extern EVP_MD       	*md;
     EVP_MD_CTX   	       	*mdctx;
-    unsigned char       	md_value[ EVP_MAX_MD_SIZE ];
+    unsigned char       	md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
     char		       	cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
     if ( cksum ) {

--- a/stor.c
+++ b/stor.c
@@ -138,8 +138,8 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
     unsigned int	md_len;
     extern EVP_MD       *md;
     EVP_MD_CTX          *mdctx = EVP_MD_CTX_new();
-    unsigned char       md_value[ EVP_MAX_MD_SIZE ];
-    char       cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
+    unsigned char       md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
+    char                cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
     /* Check for checksum in transcript */
     if ( cksum ) {
@@ -265,8 +265,8 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     unsigned int	rsrc_len;
     extern EVP_MD      	*md;
     EVP_MD_CTX         	*mdctx = EVP_MD_CTX_new();
-    unsigned char 	md_value[ EVP_MAX_MD_SIZE ];
-    char		cksum_b64[ EVP_MAX_MD_SIZE ];
+    unsigned char 	md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
+    char		cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 
     /* Check for checksum in transcript */
     if ( cksum ) {

--- a/t2pkg.c
+++ b/t2pkg.c
@@ -64,8 +64,8 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     char		*path = t->t_pinfo.pi_name;
     ssize_t		rr, size = 0;
     EVP_MD_CTX          *mdctx = EVP_MD_CTX_new();
-    unsigned char       md_value[ EVP_MAX_MD_SIZE ];
-    char       		cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
+    unsigned char       md_value[ SZ_BASE64_D( SZ_BASE64_E( EVP_MAX_MD_SIZE ) ) ];
+    char       	        cksum_b64[ SZ_BASE64_E( EVP_MAX_MD_SIZE ) ];
 #ifdef __APPLE__
     extern struct as_header as_header;
     extern struct attrlist  getalist;
@@ -559,7 +559,7 @@ main( int ac, char *av[] )
     struct stat		st;
     char		*transcript;
     char		shortname[ MAXPATHLEN ], fullpath[ MAXPATHLEN ];
-    char		tmp[ MAXPATHLEN ], src[ MAXPATHLEN ], dst[ MAXPATHLEN ];
+    char		src[ MAXPATHLEN ], dst[ MAXPATHLEN ];
     char		root[ MAXPATHLEN ] = "/";
     char		*kfile = "/dev/null";
     char		*p, *dstdir = NULL;

--- a/tls.c
+++ b/tls.c
@@ -356,7 +356,7 @@ tls_client_start( SNET *sn, char *host, int authlevel )
 		    if ( ntype != IS_DNS ) {
 			continue;
 		    };
-		    sn = (char *) ASN1_STRING_data( gn->d.ia5 );
+		    sn = (char *) ASN1_STRING_get0_data( gn->d.ia5 );
 		    sl = ASN1_STRING_length( gn->d.ia5 );
 
 		    /* ignore empty */
@@ -391,7 +391,7 @@ tls_client_start( SNET *sn, char *host, int authlevel )
 			continue;
 		    }
 
-		    sn = (char *) ASN1_STRING_data( gn->d.ia5 );
+		    sn = (char *) ASN1_STRING_get0_data( gn->d.ia5 );
 		    sl = ASN1_STRING_length( gn->d.ia5 );
 
 		    if ( ntype == IS_IP4 && sl != sizeof( struct in_addr )) {

--- a/update.c
+++ b/update.c
@@ -64,9 +64,9 @@ update( char *path, char *displaypath, int present, int newfile,
     char		type;
     char		*d_target;
 #ifdef __APPLE__
-    char			fi_data[ FINFOLEN ];
+    unsigned char		fi_data[ SZ_BASE64_D( SZ_BASE64_E( FINFOLEN ) ) ];
     extern struct attrlist	setalist;
-    static char                 null_buf[ 32 ] = { 0 };
+    static char                 null_buf[ SZ_BASE64_D( SZ_BASE64_E( FINFOLEN ) ) ] = { 0 };
 #endif /* __APPLE__ */
 
     switch ( *targv[ 0 ] ) {
@@ -140,7 +140,7 @@ update( char *path, char *displaypath, int present, int newfile,
 	    if ( setattrlist( path, &setalist,
 		    fi_data, FINFOLEN, FSOPT_NOFOLLOW ) != 0 ) {
 		fprintf( stderr,
-		    "retrieve %s failed: Could not set attributes\n", path );
+		    "retrieve %s failed: Could not set Finder Info attribute\n", path );
 		return( -1 );
 	    }
 	}


### PR DESCRIPTION
small tweaks to remove compiler warnings, added strlen for null string test
changed configure directory search paths to include fink’s use of /sw or soon /opt/sw
Corrected calculation of size of string for a base64 encode/decode avoid array overrun crash
SSL call ASN1_STRING_data -> ASN1_STRING_get0_data to avoid deprecated call
Corrected length for Finder Info encoding and clarified message
