### PR TITLE
sth-memory leak in OpenSSL calls

### DIFF
--- a/cksum.c
+++ b/cksum.c
@@ -149,6 +149,7 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
 	    size += (size_t)rc;
 	}
 	if ( close( rfd ) < 0 ) {
+	    EVP_MD_CTX_free(mdctx);
 	    return( -1 );
 	}
 	if ( rc < 0 ) {

--- a/cksum.c
+++ b/cksum.c
@@ -52,6 +52,7 @@ do_fcksum( int fd, char *cksum_b64 )
 	EVP_DigestUpdate( mdctx, buf, (unsigned int)rr );
     }
     if ( rr < 0 ) {
+	EVP_MD_CTX_free(mdctx);
 	return( -1 );
     }
 
@@ -135,10 +136,12 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
         if ( snprintf( rsrc_path, MAXPATHLEN, "%s%s",
 		path, _PATH_RSRCFORKSPEC ) >= MAXPATHLEN ) {
             errno = ENAMETOOLONG;
+	    EVP_MD_CTX_free(mdctx);
             return( -1 );
         }
 
 	if (( rfd = open( rsrc_path, O_RDONLY )) < 0 ) {
+	    EVP_MD_CTX_free(mdctx);
 	    return( -1 );
 	}
 	while (( rc = read( rfd, buf, sizeof( buf ))) > 0 ) {
@@ -149,11 +152,13 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
 	    return( -1 );
 	}
 	if ( rc < 0 ) {
+	    EVP_MD_CTX_free(mdctx);
 	    return( -1 );
 	}
     }
 
     if (( dfd = open( path, O_RDONLY, 0 )) < 0 ) {
+        EVP_MD_CTX_free( mdctx );
 	return( -1 );
     }
     /* checksum data fork */
@@ -162,9 +167,11 @@ do_acksum( char *path, char *cksum_b64, struct applefileinfo *afinfo )
 	size += (size_t)rc;
     }
     if ( rc < 0 ) {
+        EVP_MD_CTX_free( mdctx );
 	return( -1 );
     }
     if ( close( dfd ) < 0 ) {
+        EVP_MD_CTX_free( mdctx );
 	return( -1 );
     }
 

--- a/t2pkg.c
+++ b/t2pkg.c
@@ -83,6 +83,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     if ( cksum ) {
 	if ( strcmp( trancksum, "-" ) == 0 ) {
 	    fprintf( stderr, "line %d: no checksum\n", t->t_linenum );
+	    EVP_MD_CTX_free( mdctx );
 	    return( -1 );
 	}
 	EVP_DigestInit( mdctx, md );
@@ -90,6 +91,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 
     if (( rfd = open( src, O_RDONLY, 0 )) < 0 ) {
 	perror( src );
+	EVP_MD_CTX_free( mdctx );
 	return( -1 );
     }
     if (( wfd = open( dst, O_CREAT | O_WRONLY | O_EXCL, 0666 )) < 0 ) {
@@ -105,6 +107,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     if ( snprintf( rsrcpath, MAXPATHLEN, "%s%s", dst, _PATH_RSRCFORKSPEC )
 		>= MAXPATHLEN ) {
 	fprintf( stderr, "%s%s: path too long.\n", dst, _PATH_RSRCFORKSPEC );
+	EVP_MD_CTX_free( mdctx );
 	return( -1 );
     } 
 
@@ -387,7 +390,6 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e( md_value, md_len, ( char * )cksum_b64 );
-        EVP_MD_CTX_free(mdctx);
 	if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    if ( force ) {
 		fprintf( stderr, "warning: " );
@@ -398,7 +400,7 @@ copy_file( struct transcript *t, char *dst, char *src, int where )
 	    }
 	}
     }
-
+    EVP_MD_CTX_free( mdctx );
     return( 0 );
 
 error2:
@@ -413,6 +415,7 @@ error2:
     }
 
 error1:
+    EVP_MD_CTX_free( mdctx );
     return( -1 );
 }
 

--- a/transcript.c
+++ b/transcript.c
@@ -373,7 +373,7 @@ t_print( struct pathinfo *fs, struct transcript *tran, int flag )
 		sizeof( null_buf )) != 0 ) { 
 	    char	finfo_e[ SZ_BASE64_E( FINFOLEN ) ];
 
-	    base64_e( (char *)cur->pi_afinfo.ai.ai_data, FINFOLEN, finfo_e );
+	    base64_e( (unsigned char *)cur->pi_afinfo.ai.ai_data, FINFOLEN, finfo_e );
 	    fprintf( outtran, "%c %-37s\t%.4lo %5d %5d %s\n", cur->pi_type,
 		    epath,
 		    (unsigned long)( T_MODE & cur->pi_stat.st_mode ), 


### PR DESCRIPTION
There are numerous occasions where a OpenSSL call to free is not called before exiting functions that have an OpenSSL call to new.  Inserted the free call before all return functions.