### PR TITLE
Patch to ignore timestamps with -t option for smaller transcripts.

### DIFF
--- a/fsdiff.c
+++ b/fsdiff.c
@@ -33,6 +33,7 @@ int		dotfd;
 int		lastpercent = -1;
 int		case_sensitive = 1;
 int		tran_format = -1; 
+int		ignore_timestamps = 0;
 extern int	exclude_warnings;
 const EVP_MD    *md;
 
@@ -401,7 +402,7 @@ main( int argc, char **argv )
     cksum = 0;
     outtran = stdout;
 
-    while (( c = getopt( argc, argv, "%1ACc:IK:o:VvW" )) != EOF ) {
+    while (( c = getopt( argc, argv, "%1ACc:IK:o:tVvW" )) != EOF ) {
 	switch( c ) {
 	case '%':
 	case 'v':
@@ -454,6 +455,10 @@ main( int argc, char **argv )
 	case 'W':		/* print a warning when excluding an object */
 	    exclude_warnings = 1;
 	    break;
+
+	case 't':		/* ignore files for which only the time has changed */
+	    ignore_timestamps = 1;
+	break;
 
 	case '?':
 	    printf( "bad %c\n", c );

--- a/man/fsdiff.1
+++ b/man/fsdiff.1
@@ -11,7 +11,7 @@
 |
 .B -1
 } [
-.BI -IVW
+.BI -IVWt
 ] [
 .BI \-K\  command
 ] [
@@ -312,6 +312,9 @@ order of preference and then exits.
 prints a warning to the standard error when encountering an object
 matching an exclude pattern.
 .sp
+.TP 19
+.B \-t
+ignores files where only the timestamp has changed.
 .SH FILES
 .TP 19
 .B _RADMIND_COMMANDFILE

--- a/transcript.c
+++ b/transcript.c
@@ -43,6 +43,7 @@ static struct transcript	*prev_tran = NULL;
 extern int			edit_path;
 extern int			case_sensitive;
 extern int			tran_format;
+extern int			ignore_timestamps;
 static char			*kdir;
 static struct list		*kfile_list;
 struct list			*special_list;
@@ -50,6 +51,7 @@ struct list			*exclude_list;
 
 char				*path_prefix = NULL;
 int				edit_path;
+int				ignore_timestamps;
 int				skip = 0;
 int				cksum;
 int				fs_minus;
@@ -550,14 +552,16 @@ t_compare( struct pathinfo *fs, struct transcript *tran )
 		    t_print( fs, tran, PR_DOWNLOAD );
 		    break;
 		}
-	    } else if ( fs->pi_stat.st_mtime != tran->t_pinfo.pi_stat.st_mtime ) {
-		t_print( fs, tran, PR_DOWNLOAD );
-		break;
+	    } else if ( ignore_timestamps == 0 &&
+			fs->pi_stat.st_mtime != tran->t_pinfo.pi_stat.st_mtime) {
+		    t_print( fs, tran, PR_DOWNLOAD );
+		    break;
 	    }
 
-	    if ( fs->pi_stat.st_mtime != tran->t_pinfo.pi_stat.st_mtime ) {
-		t_print( fs, tran, PR_STATUS );
-		break;
+	    if ( ignore_timestamps == 0 &&
+		 fs->pi_stat.st_mtime != tran->t_pinfo.pi_stat.st_mtime ) {
+		    t_print( fs, tran, PR_STATUS );
+		    break;
 	    }
 	}
 


### PR DESCRIPTION
Uploading a file to the server for just a timestamp change should be avoided in most cases.  Makes for smaller transcripts and less files stored that are identical.  Documentation patched for new (-t) option.