### PR TITLE
Allow \<space> to replace \b to represent blanks in file names.

### DIFF
--- a/argcargv.c
+++ b/argcargv.c
@@ -45,6 +45,7 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 {
     int		ac;
     int		state;
+    char *      pline = line;
 
     if ( acav == NULL ) {
 	if ( acavg == NULL ) {
@@ -60,7 +61,6 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 
     for ( ; *line != '\0'; line++ ) {
 	switch ( *line ) {
-	case ' ' :
 	case '\t' :
 	case '\n' :
 	    if ( state == ACV_WORD ) {
@@ -68,6 +68,14 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 		state = ACV_WHITE;
 	    }
 	    break;
+	case ' ' :
+	  if ( ( line == pline ) || ( *(line-1) != '\\') ) {
+	        if ( state == ACV_WORD ) {
+		    *line = '\0';
+		    state = ACV_WHITE;
+	        }
+	        break;
+	    }
 	default :
 	    if ( state == ACV_WHITE ) {
 		acav->acv_argv[ ac++ ] = line;

--- a/code.c
+++ b/code.c
@@ -34,7 +34,7 @@ encode( char *line )
 	case ' ' :
 	    *temp = '\\';
 	    temp++;
-	    *temp = 'b';
+	    *temp = ' ';
 	    break;
 	case '\t' :
 	    *temp = '\\';
@@ -96,6 +96,7 @@ decode( char *line )
 		*temp = '\t';
 		break;
 	    case 'b':
+	    case ' ':
 		*temp = ' ';
 		break;
 	    case 'r':


### PR DESCRIPTION
  Make transcript lines compatible with shell commands.  This makes copying a line from the transcript easy to the command line for listing, checking attributes or any other operation a simple cut and paste.  Previously this has needed to replace all the \b with \<space> characters.

fsdiff will still read and interpret \b as a space for comparison so previous transcripts do not need to be modified.  New transcripts will be written in the \<space> format.