### PR TITLE
Updated work flow to load missing components on macOS AND to checkout…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+	with:
+	  submodules: recursive
       - name: Configure
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
-              brew install openssl
+              brew install openssl cyrus-sasl autoconf
               sudo ln -s /usr/local/opt/openssl /usr/local/openssl 
           fi
           sh bootstrap.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-	with:
-	  submodules: recursive
+        with:
+          submodules: recursive
       - name: Configure
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then


### PR DESCRIPTION
Makes the code checkout recursive so the submodule is loaded avoiding build failure on all OS.
Adds a few components to brew install that are missing from a bare macOS system, (I use fink instead of brew but I think the list of components are the same).