### PR TITLE
sth fixes - one memory crash and some formatting and build options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+	with:
+	  submodules: recursive
       - name: Configure
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
-              brew install openssl
+              brew install openssl cyrus-sasl autoconf
               sudo ln -s /usr/local/opt/openssl /usr/local/openssl 
           fi
           sh bootstrap.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-	with:
-	  submodules: recursive
+        with:
+          submodules: recursive
       - name: Configure
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then

--- a/Makefile.in
+++ b/Makefile.in
@@ -394,7 +394,7 @@ clean :
 	rm -rf tmp
 
 distclean: clean
-	rm -f config.log config.status Makefile config.h
-	rm -rf autom4te.cache
+	rm -f config.log config.status config.cache Makefile config.h configure
+	rm -rf autom4te.cache profiled
 	rm -rf .#*
 	cd libsnet; make distclean

--- a/README.md
+++ b/README.md
@@ -90,16 +90,20 @@ brew install openssl
 sudo ln -s /usr/local/opt/openssl /usr/local/openssl 
 ```
 
-Last tested on 10.14 (using fink)
+Last tested on MacOS 13.6 (using fink)
 
 - Install [Xcode](https://developer.apple.com/xcode/).
 - Install [fink](https://finkproject.org).
 
-Run these commands as an admin user.
-
+Run these commands as and admin user.
 ```
-fink install autoconf
-fink install openssl
+fink install autoconf2.6 openssl110-dev cyrus-sasl2.3-dev
+cd libsnet
+autoconf
+cd ..
+autoconf
+./configure LDFLAGS='-L/opt/sw/lib -lsasl2' CFLAGS='-I/opt/sw/include'
+make all
 ```
 
 ### Configuring for Raspbian Stretch (Debian 9)

--- a/README.md
+++ b/README.md
@@ -96,13 +96,23 @@ Last tested on MacOS 13.6 (using fink)
 - Install [fink](https://finkproject.org).
 
 Run these commands as and admin user.
+
+If making universal binaries -use lipo after fink, to create universal binaries, for libsasl2.3.dylib, libssl.1.1.dylib, and libcrypto.1.1.dylib)
+For example if you have another architecture mounted remotely
+```
+cd /opt/sw/lib
+sudo lipo -create -output libsasl2.3.dylib libsasl2.3.dylib /Volumes/<remote with other arch>/opt/sw/lib/libsasl2.3.dylib
+```
+Will create the library on the local volume for the libsasl, the other 2 libraries can be merged the same way.
+
 ```
 fink install autoconf2.6 openssl110-dev cyrus-sasl2.3-dev
+
 cd libsnet
 autoconf
 cd ..
 autoconf
-./configure LDFLAGS='-L/opt/sw/lib -lsasl2' CFLAGS='-I/opt/sw/include'
+./configure LDFLAGS='-L/opt/sw/lib -lsasl2' CFLAGS='-I/opt/sw/include' --with-zlib=/opt/sw/lib/ --enable-universal-binaries
 make all
 ```
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -112,6 +112,13 @@ AC_DEFUN([CHECK_UNIVERSAL_BINARIES],
 	    LDFLAGS="$LDFLAGS -L/Developer/SDKs/$macosx_sdk/usr/lib"
 	    ;;
 
+	  darwin22*|darwin21*|darwin20*)
+	    dep_target="-mmacosx-version-min=10.9"
+	    arches="-arch x86_64 -arch arm64"
+	    macosx_sdk="`xcrun --show-sdk-path`"
+	    LDFLAGS="$LDFLAGS -L$macosx_sdk/usr/lib"
+	    ;;
+
 	  *)
             AC_MSG_ERROR([Building universal binaries on ${host_os} is not supported])
 	    ;;
@@ -120,7 +127,7 @@ AC_DEFUN([CHECK_UNIVERSAL_BINARIES],
 	echo ===========================================================
 	echo Setting up universal binaries for ${host_os}
 	echo ===========================================================
-	OPTOPTS="$OPTOPTS -isysroot /Developer/SDKs/$macosx_sdk $dep_target $arches"
+	OPTOPTS="$OPTOPTS -isysroot $macosx_sdk $dep_target $arches"
     fi
 ])
 

--- a/argcargv.c
+++ b/argcargv.c
@@ -45,6 +45,7 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 {
     int		ac;
     int		state;
+    char *      pline = line;
 
     if ( acav == NULL ) {
 	if ( acavg == NULL ) {
@@ -60,7 +61,6 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 
     for ( ; *line != '\0'; line++ ) {
 	switch ( *line ) {
-	case ' ' :
 	case '\t' :
 	case '\n' :
 	    if ( state == ACV_WORD ) {
@@ -68,6 +68,14 @@ acav_parse( ACAV *acav, char *line, char **argv[] )
 		state = ACV_WHITE;
 	    }
 	    break;
+	case ' ' :
+	  if ( ( line == pline ) || ( *(line-1) != '\\') ) {
+	        if ( state == ACV_WORD ) {
+		    *line = '\0';
+		    state = ACV_WHITE;
+	        }
+	        break;
+	    }
 	default :
 	    if ( state == ACV_WHITE ) {
 		acav->acv_argv[ ac++ ] = line;

--- a/code.c
+++ b/code.c
@@ -34,7 +34,7 @@ encode( char *line )
 	case ' ' :
 	    *temp = '\\';
 	    temp++;
-	    *temp = 'b';
+	    *temp = ' ';
 	    break;
 	case '\t' :
 	    *temp = '\\';
@@ -96,6 +96,7 @@ decode( char *line )
 		*temp = '\t';
 		break;
 	    case 'b':
+	    case ' ':
 		*temp = ' ';
 		break;
 	    case 'r':

--- a/retr.c
+++ b/retr.c
@@ -548,12 +548,11 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
-	base64_e(( char*)&md_value, md_len, cksum_b64 );
-        EVP_MD_CTX_free(mdctx);
+	base64_e( ( unsigned char * ) &md_value, md_len, cksum_b64 );
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
 		"checksum from server\n", linenum );
-	fprintf( stderr, "%s\n", pathdesc );
+	    fprintf( stderr, "%s\n", pathdesc );
             returnval = 1;
 	    goto error1;
         }
@@ -568,6 +567,7 @@ error2:
     close( dfd );
 error1:
     unlink( temppath );
+    EVP_MD_CTX_free(mdctx);
     return( returnval );
 }
 

--- a/retr.c
+++ b/retr.c
@@ -210,7 +210,6 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
 	base64_e( md_value, md_len, cksum_b64 );
-	EVP_MD_CTX_free(mdctx);
 	if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
 		"checksum from server\n", linenum );

--- a/retr.c
+++ b/retr.c
@@ -548,7 +548,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
-	base64_e( ( unsigned char * ) &md_value, md_len, cksum_b64 );
+	base64_e( ( unsigned char * ) md_value, md_len, cksum_b64 );
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
 		"checksum from server\n", linenum );

--- a/retr.c
+++ b/retr.c
@@ -199,7 +199,7 @@ retr( SNET *sn, char *pathdesc, char *path, char *temppath, mode_t tempmode,
     /* cksum file */
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
-	base64_e( md_value, md_len, cksum_b64 );
+	base64_e( ( unsigned char * ) md_value, md_len, cksum_b64 );
 	EVP_MD_CTX_free(mdctx);
 	if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "
@@ -526,7 +526,7 @@ retr_applefile( SNET *sn, char *pathdesc, char *path, char *temppath,
 
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
-	base64_e(( char*)&md_value, md_len, cksum_b64 );
+	base64_e( ( unsigned char* ) md_value, md_len, cksum_b64 );
         EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr, "line %d: checksum in transcript does not match "

--- a/stor.c
+++ b/stor.c
@@ -239,7 +239,7 @@ stor_file( SNET *sn, char *pathdesc, char *path, off_t transize,
     /* cksum data sent */
     if ( cksum ) {
 	EVP_DigestFinal( mdctx, md_value, &md_len );
-	base64_e( md_value, md_len, cksum_b64 );
+	base64_e( ( unsigned char * )  md_value, md_len, cksum_b64 );
 	EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr,
@@ -466,7 +466,7 @@ stor_applefile( SNET *sn, char *pathdesc, char *path, off_t transize,
     /* cksum data sent */
     if ( cksum ) {
         EVP_DigestFinal( mdctx, md_value, &md_len );
-        base64_e( ( char*)&md_value, md_len, cksum_b64 );
+        base64_e( ( unsigned char * ) md_value, md_len, cksum_b64 );
 	EVP_MD_CTX_free(mdctx);
         if ( strcmp( trancksum, cksum_b64 ) != 0 ) {
 	    fprintf( stderr,


### PR DESCRIPTION
This fixes a double free call that somehow was a code regression causing crashes.  Updates aclocal.m4 to handle building universal binaries for macOS (arm64 and x86_64).  Limits make to single job in libsnet subdirectory to avoid error with lipo building fat binary.  Adjust formatting to original scheme in a few places.